### PR TITLE
fix creator meta tag

### DIFF
--- a/simple-fediverse-creator.php
+++ b/simple-fediverse-creator.php
@@ -79,7 +79,7 @@ function simplefediversecreator_meta_tag() {
     }
     if ( !empty( $simplefediversecreator_username ) ) {
         $simplefediversecreator_id = explode("/", $simplefediversecreator_username);
-        echo '<meta property="fediverse:creator" name="fediverse:creator" content="' . esc_attr(sanitize_email( $simplefediversecreator_username )) . '"/>' . "\n";
+        echo '<meta name="fediverse:creator" content="@' . esc_attr(sanitize_email( $simplefediversecreator_username )) . '"/>' . "\n";
     }
 }
 add_action( 'wp_head', 'simplefediversecreator_meta_tag');


### PR DESCRIPTION
According to the official [blog](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/) the meta tag has another format. This PR fixes it.